### PR TITLE
docs: add gh skill publishing instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,3 +172,22 @@ Do not use sleeps, branch-name polling, `mq logs`, `mq events`, or
 - Prefer deleting stale docs over re-dating them. Git history already preserves old text; the live docs tree should describe current reality, not accumulate dead docs.
 - Removing stale or duplicate docs is a good default behavior. `rm` is often the right answer.
 - Run `pnpm docs:lint` before merging doc structure or policy changes.
+
+### Publishing Skills
+
+This repo uses `gh skill publish` (GitHub CLI v2.90.0+) to publish skills.
+
+**Prerequisite:** Ensure GitHub CLI v2.90.0+ is installed: `gh --version`
+
+**When modifying skills:**
+1. Make changes to skill files in `skills/{skill-name}/`
+2. Commit and merge to main
+3. Run `gh skill publish --tag vX.Y.Z` to create a release
+4. The `agent-skills` topic will be added automatically
+
+**Installing skills from this repo:**
+```bash
+gh skill install recallnet/codecontext codecontext-setup --agent codex
+```
+
+See: https://cli.github.com/manual/gh_skill_publish


### PR DESCRIPTION
## Summary

Document the GitHub CLI v2.90.0+ requirement and publishing workflow for skills in this repo.

## Changes

Added Publishing Skills section to AGENTS.md that covers:
- Prerequisite: GitHub CLI v2.90.0+ required (gh --version)
- Workflow: Make changes → Commit → Merge → gh skill publish --tag vX.Y.Z
- Consumer install command: gh skill install recallnet/codecontext codecontext-setup --agent codex

## Context

This aligns with the migration from npx skills to native gh skill CLI across Recall repos. See skunkworks-template PR #19 for the main migration.

## Related

- https://cli.github.com/manual/gh_skill_publish
- https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/